### PR TITLE
refactor: delete comments and empty spaces (Mon, March 13, 0.48.36pm)

### DIFF
--- a/cssBayan/styles.css
+++ b/cssBayan/styles.css
@@ -110,7 +110,6 @@ input:checked + .accordion__label .plus {
     }
 }
 
-
 @media screen and (max-width: 1024px) {
     .accordion-wrapper {
         max-width: 80%;


### PR DESCRIPTION
1. Task: https://github.com/DrDiman/CSS-Bayan-task
2. Screenshot:
![cssBayan](https://user-images.githubusercontent.com/102792249/224576035-1d2218d9-7523-4e37-8f90-a3fb108e862b.png)
3. Deploy: https://irabebenina.github.io/cssBayan/cssBayan/index.html
4. Done 13.03.2023
5. Score: 140/140
Everything is done from Repository requirements and how to submit task section (30)
The accordion component is centered on the screen, with equal indents on the left and right (10)
Icons, meme texts and meme images are exist (5)
Placement of the meme, icons and meme text are the same as in provided example gif images (5)
Smooth change (transition) of the meme images and icons is done (20)
Responsive design with three breakpoints for mobile, tablet, and desktop exist. Accordion is displayed correctly at mobile 320x568, tablet 820x1180, desktop 1920×1080. (Note: breakpoints don't have to be 320x568, 820x1180, 1920x1080). (10)
All visual effects when the cursor is hovering over the memes, when the mouse is down on a meme, and when a meme is selected are implemented (10)
The entire row (text, icon, and meme image) clickable (5)
Cursor over the memes (hover) effect only exists for devices that can support hover. (10)
The cursor when it is hovering over the rows of the accordion is changing (5)
Only flexible dimensions are used rem, em, %, vh, vw, fr and etc... The accordion is responsive (10)
All blocks/parts of the accordion are in base flow of the dom elements. All elements are not positioned with top, left, right, bottom. float is not used. The value of position is only static (5)
Pseudo-elements are not used (note 1: pseudo-classes are allowed; note 2: pseudo-elements only from FontAwesome are allowed) (5)
Initially, the first meme should be expanded (5)
Font size is changed at each device (mobile, tablet, desktop) (5)